### PR TITLE
Enable a timeout to be sent to the tunnel

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -107,15 +107,17 @@ program
   .action(makeATunnel)
 
 function makeATunnel(hostAndPort){
-  makeBS().tunnel({
+  var tunnel = makeBS().tunnel({
     hostAndPort: hostAndPort,
     key: program.key,
     usePrivateKey: program['private'],
     timeout: program.timeout * 1000
   }, exitIfErrorElse(function(){
     console.log('Tunnel is running.')
-    process.stdin.resume()
   }))
+  hangOnTillExit(function(){
+    tunnel.stop()
+  })
 }
 
 program


### PR DESCRIPTION
I have separately added support to the tunnel for receiving the timeout in the options.
https://github.com/airportyh/browseroverflow/pull/1

I have used the same -t switch, but documented it separately in the tunnel command. Perhaps the documentation of the main -t switch should be updated to mention it's also for tunnel timeout?

I needed to extend the timeout of the tunnel for my environment and as it's an arbitrary measurement it seems like a good idea to make it an option.

I also added code that kills the tunnel when the CLI process is killed, so we don't leave it dangling, especially as the tunnel jar checks if there is already one running and fails if there is. The kill hook is registered before the tunnel has opened so we still kill it if the process is killed before the tunnel is established.
