### PR TITLE
Add --timeout option for launch and fix Validation Failed required `os` issue

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -36,21 +36,21 @@ program
 function launchBrowser(browserSpec, url){
   var browser = browserSpec.split(':')[0]
   var version = browserSpec.split(':')[1]
-  var os_name
-  var os_version
-  if (program.os){
-    var parts = program.os.split(':')
-    os_name = parts[0]
-    os_version = parts[1]
-  }
-  makeBS().launch({
+
+  var options = {
     browser: browser,
     browser_version: version,
-    os: os_name,
-    os_version: os_version,
     url: url,
     timeout: program.timeout
-  }, exitIfErrorElse(function(job){
+  }
+
+  if (program.os){
+    var parts = program.os.split(':')
+    options.os_name = parts[0]
+    options.os_version = parts[1]
+  }
+
+  makeBS().launch(options, exitIfErrorElse(function(job){
     console.log('Launched job ' + job.id + '.')
     if (program.attach){
       console.log('Ctrl-C to kill job.')


### PR DESCRIPTION
I made two changes. First I added support for --timeout when launching the browser as explained here:

https://github.com/browserstack/api#timeout30

with this new feature I'm able to launch a browser for less than 5 minutes (300secs) which is the default. 5 minutes is a lot for unit tests.

Secondly, I fixed a bug in the current version that make this simple case fail:

```
browserstack launch firefox:3.6 http://google.com
```

because it sends `os: undefined` to browserflow and browserflow only check the property exists but not its value. So, it call the http API without os.

Please, I'd love if you can open up issues for this repository.
