### PR TITLE
There is no 'os_name' flag in neither Browseroverflow nor the Browsersta...

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -46,7 +46,7 @@ function launchBrowser(browserSpec, url){
 
   if (program.os){
     var parts = program.os.split(':')
-    options.os_name = parts[0]
+    options.os = parts[0]
     options.os_version = parts[1]
   }
 


### PR DESCRIPTION
...ck APIs. The correct flag to use for the Operating System name is simply 'os'.
